### PR TITLE
1.3.4 Hello, world!　演習1&2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def hola
-    render html: "hola, mundo!"
+    render html: "¡hola, mundo!"
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  def hello
-    render html: "hello, world!"
+  def hola
+    render html: "hola, mundo!"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  root 'application#hello'
+  root 'application#hola'
 end


### PR DESCRIPTION
ref：[1\.3\.4 Hello, world\!　演習 · Issue \#2 · rsym/hello\_app](https://github.com/rsym/hello_app/issues/2#issue-705378968)

> 1. リスト 1.7のhelloアクションを書き換え、「hello, world!」の代わりに「hola, mundo!」と表示されるようにしてみましょう。
> 2. Railsでは「非ASCII文字」もサポートされています。「¡Hola, mundo!」にはスペイン語特有の逆さ感嘆符「¡」が含まれています (図 1.16)18 。「¡」文字をMacで表示するには、Optionキーを押しながら1キーを押します。この文字をコピーして自分のエディタに貼り付ける方が早いかもしれません。